### PR TITLE
Install ssl-vision if no argument is passed to configure.sh

### DIFF
--- a/ssl-vision/configure.sh
+++ b/ssl-vision/configure.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 "${SCRIPT_DIR}"/configure-chrony.sh
 "${SCRIPT_DIR}"/configure-vnc.sh
 "${SCRIPT_DIR}"/configure-spinnaker.sh
-if [ "$1" == "vp" ];
+if [[ "${1:-}" == "vp" ]]; 
   then
     "${SCRIPT_DIR}"/configure-vision-processor.sh
   else


### PR DESCRIPTION
 https://github.com/RoboCup-SSL/ssl-setup/blob/512f7ae99c7feda2423cd8f1bf0fa5e06ad79aea/ssl-vision/configure.sh#L18
 
 This line makes configure.sh script break if no argument is passed. This PR changes it to install ssl-vision if no argument is passed.